### PR TITLE
9316 - Angular demo - Fix text-center inside bonus edition

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -71,7 +71,7 @@
 					  [attr.operator-id]="operatorId"
 					  [attr.user-id]="userId"
 					  [attr.session-id]="sessionId"
-					  locale="en-NZ"
+					  locale="en"
 					  currency="EUR"
 					  country="IRL"
 					  user-data="{}"


### PR DESCRIPTION
[Story sc-9316](https://app.shortcut.com/soltech/story/9316/angular-demo-fix-text-center-inside-bonus-edition)

- Change widget language to en instead of en-NZ
The English (New Zealand) content had the old version of the informations field for BlixtPay, so the CSS inside was setting the text to text-align-center.
The content has been updated to the English one