### PR TITLE
13154 - Angular demo - fix height of inline Quick Deposit

### DIFF
--- a/src/app/features/gameplay/gameplay.component.css
+++ b/src/app/features/gameplay/gameplay.component.css
@@ -19,6 +19,7 @@
 		position: absolute;
 		inset: calc(100% + 16px) 32px 0 auto;
 		min-inline-size: 532px;
+		block-size: 64px;;
 	}
 }
 


### PR DESCRIPTION
[Story sc-13154](https://app.shortcut.com/soltech/story/13154/angular-demo-fix-height-of-inline-quick-deposit)

Fix: Add `block-size` property in inline quick deposit wrapper